### PR TITLE
Add WithLogger and configure logger into remote sampler

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,13 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         - name: OTEL_SAMPLER_JAEGER_CONFIG_URL_TEMPLATE
-          value: http://${OTEL_EXPORTER_JAEGER_AGENT_HOST}:5778/sampling?service={}
+          value: http://${OTEL_EXPORTER_JAEGER_AGENT_HOST}:5778/
 ```
+
+Please note that there are a few similar-looking URLs floating around for the URL_TEMPLATE.
+The different URLs are meant for different collector libraries and have subtly different
+output. You likely need to change your URL_TEMPLATE if you are migrating from a different
+telemetry library so note carefully this syntax.
 
 ### EnvironCarrier
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module barney.ci/go-otel
 go 1.16
 
 require (
+	github.com/go-logr/logr v1.2.3
+	github.com/go-logr/stdr v1.2.2
 	go.opentelemetry.io/contrib/samplers/jaegerremote v0.6.0
 	go.opentelemetry.io/otel v1.11.2
 	go.opentelemetry.io/otel/exporters/jaeger v1.11.2

--- a/setup.go
+++ b/setup.go
@@ -121,7 +121,6 @@ func WithRemoteSampler() setupOptionFunc {
 	return setupOptionFunc(func(opts *setupConfig) {
 		if samplerURL := os.Getenv(EnvSamplerTemplateName); samplerURL != "" {
 			samplerURL = os.ExpandEnv(samplerURL)
-			samplerURL = strings.ReplaceAll(samplerURL, "{}", url.QueryEscape(opts.name))
 			opts.sampler = jaegerremote.New(opts.name,
 				jaegerremote.WithSamplingServerURL(samplerURL),
 				jaegerremote.WithInitialSampler(opts.sampler),

--- a/setup.go
+++ b/setup.go
@@ -2,13 +2,10 @@ package otel
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log"
-	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -97,14 +94,6 @@ func WithLogger(logger logr.Logger) setupOptionFunc {
 	})
 }
 
-// WithErrorPrinter is now deprecated and does not do anything.
-// Errors are now printed by default. This can be changed by using
-// the WithLogger optionfunc.
-// Deprecated: Use WithLogger instead.
-func WithErrorPrinter(_ interface{}) setupOptionFunc {
-	return setupOptionFunc(func(opts *setupConfig) {})
-}
-
 // WithSampler causes JaegerSetup to configure Jaeger
 // with the provided sampler only
 func WithSampler(s trace.Sampler) setupOptionFunc {
@@ -174,8 +163,7 @@ func JaegerSetup(name string, with ...setupOptionFunc) (
 	}
 	defer func() {
 		if r := recover(); r != nil {
-			err = errors.New(fmt.Sprintf("%s", r))
-			opts.logger.Error(err, "panic occurred in JaegerSetup")
+			opts.logger.Error(fmt.Errorf("%s", r), "panic occurred in JaegerSetup")
 		}
 	}()
 	for _, fn := range with {
@@ -209,7 +197,7 @@ func JaegerSetup(name string, with ...setupOptionFunc) (
 			ctx = context.Background()
 		}
 		err := tp.Shutdown(ctx)
-		opts.logger.Error(err, "Shutdown error")
+		opts.logger.Error(err, "jaeger shutdown error")
 		return err
 	})
 

--- a/setup.go
+++ b/setup.go
@@ -100,6 +100,7 @@ func WithLogger(logger logr.Logger) setupOptionFunc {
 // WithErrorPrinter is now deprecated and does not do anything.
 // Errors are now printed by default. This can be changed by using
 // the WithLogger optionfunc.
+// Deprecated: Use WithLogger instead.
 func WithErrorPrinter(_ interface{}) setupOptionFunc {
 	return setupOptionFunc(func(opts *setupConfig) {})
 }


### PR DESCRIPTION
With this change, it is now possible to inject a logger into the jaeger remote sampler. This makes it much easier to debug certain configuration issues causing the sampler to not work.

The stdlib log.Default() logger will be used by default. This is a change of behavior from before where no logger was used by default. Users can still disable logging by calling WithLogger(logr.Discard()), but it seems to me that errors should be exposed to the user by default.

the github.com/go-logr/logr family provides quite a few wrapper types so that other standard loggers can be used with this interface.