### PR TITLE
Firmly deprecate `{}` in sampler URL template

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,8 @@ spec:
           value: http://${OTEL_EXPORTER_JAEGER_AGENT_HOST}:5778/
 ```
 
-Please note that there are a few similar-looking URLs floating around for the URL_TEMPLATE.
-The different URLs are meant for different collector libraries and have subtly different
-output. You likely need to change your URL_TEMPLATE if you are migrating from a different
-telemetry library so note carefully this syntax.
+Please note that the URL_TEMPLATE should *not* be formed with `/sampling` or `/sampling?service={}`,
+and that the use of `{}` to designate the TracerProvider name is no longer supported.
 
 ### EnvironCarrier
 

--- a/setup.go
+++ b/setup.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -109,6 +110,10 @@ func WithSampler(s trace.Sampler) setupOptionFunc {
 func WithRemoteSampler() setupOptionFunc {
 	return setupOptionFunc(func(opts *setupConfig) {
 		if samplerURL := os.Getenv(EnvSamplerTemplateName); samplerURL != "" {
+			if strings.Contains(samplerURL, "{}") {
+				panic(fmt.Sprintf("%s no longer supports {} macro; "+
+					"please see the barney.ci/go-otel readme", EnvSamplerTemplateName))
+			}
 			samplerURL = os.ExpandEnv(samplerURL)
 			opts.sampler = jaegerremote.New(opts.name,
 				jaegerremote.WithSamplingServerURL(samplerURL),


### PR DESCRIPTION
The use of `{}` to designate the TracerProvider name is no longer supported in the `OTEL_SAMPLER_JAEGER_CONFIG_URL_TEMPLATE`. Panic if we find it.

Also update the README to warn more specifically about the old format.