### PR TITLE
fix: `setup`: `JaegerSetup`: `closerFunc`: log error only when `err` is not `nil`

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -202,7 +202,9 @@ func JaegerSetup(name string, with ...setupOptionFunc) (
 			ctx = context.Background()
 		}
 		err := tp.Shutdown(ctx)
-		opts.logger.Error(err, "jaeger shutdown error")
+		if err != nil {
+			opts.logger.Error(err, "jaeger shutdown error")
+		}
 		return err
 	})
 


### PR DESCRIPTION
This change fixes [BUG942727](https://bugsby.infra.corp.arista.io/942727) by avoiding logging when the error object returned by
[`"go.opentelemetry.io/otel/sdk/trace".(*TraceProvider).Shutdown`](https://pkg.go.dev/go.opentelemetry.io/otel/sdk/trace#TracerProvider.Shutdown) is `nil`.