### PR TITLE
compat: fix UberTraceContext extraction

### DIFF
--- a/uber.go
+++ b/uber.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"regexp"
+	"strconv"
 
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
@@ -105,12 +106,16 @@ func (tc UberTraceContext) extract(carrier propagation.TextMapCarrier) trace.Spa
 	}
 	copy(scc.SpanID[:], spanID[:8])
 
-	flags, err := hex.DecodeString(matches[4])
+	flags, err := strconv.ParseInt(matches[4], 16, 64)
 	if err != nil {
+		for i, v := range matches {
+			fmt.Printf("[%v]: %q\n", i, v)
+		}
+		fmt.Println("could not decode:", matches[4])
 		return trace.SpanContext{}
 	}
 	// Clear all flags other than the trace-context supported sampling bit.
-	scc.TraceFlags = trace.TraceFlags(flags[0]) & trace.FlagsSampled
+	scc.TraceFlags = trace.TraceFlags(flags) & trace.FlagsSampled
 
 	sc := trace.NewSpanContext(scc)
 	if !sc.IsValid() {

--- a/uber.go
+++ b/uber.go
@@ -108,10 +108,6 @@ func (tc UberTraceContext) extract(carrier propagation.TextMapCarrier) trace.Spa
 
 	flags, err := strconv.ParseInt(matches[4], 16, 64)
 	if err != nil {
-		for i, v := range matches {
-			fmt.Printf("[%v]: %q\n", i, v)
-		}
-		fmt.Println("could not decode:", matches[4])
 		return trace.SpanContext{}
 	}
 	// Clear all flags other than the trace-context supported sampling bit.

--- a/uber_test.go
+++ b/uber_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2024 Arista Networks, Inc.  All rights reserved.
+// Arista Networks, Inc. Confidential and Proprietary.
+
+package otel
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func assertString(t *testing.T, expected, actual string) {
+	t.Helper()
+	if expected != actual {
+		t.Fatalf("mismatch, expected %q, actual %q", expected, actual)
+	}
+}
+
+func TestUberTraceIDExtraction(t *testing.T) {
+	for _, tc := range []struct {
+		header        string
+		expectTraceID string
+		expectSpanID  string
+		expectFlag    byte
+	}{
+		// short trace id
+		{
+			header:        "5775daa08825b4b9:5c301b3cb0f66539:114d5e5bcc8bc4c8:1",
+			expectTraceID: "00000000000000005775daa08825b4b9",
+			expectSpanID:  "5c301b3cb0f66539",
+			expectFlag:    1,
+		},
+		{
+			header:        "5775daa08825b4b9:5c301b3cb0f66539:114d5e5bcc8bc4c8:01",
+			expectTraceID: "00000000000000005775daa08825b4b9",
+			expectSpanID:  "5c301b3cb0f66539",
+			expectFlag:    1,
+		},
+		// long trace id
+		{
+			header:        "ee2ec3bb2402eb08625a76f762fb73bb:5c301b3cb0f66539:114d5e5bcc8bc4c8:1",
+			expectTraceID: "ee2ec3bb2402eb08625a76f762fb73bb",
+			expectSpanID:  "5c301b3cb0f66539",
+			expectFlag:    1,
+		},
+		{
+			header:        "ee2ec3bb2402eb08625a76f762fb73bb:5c301b3cb0f66539:114d5e5bcc8bc4c8:01",
+			expectTraceID: "ee2ec3bb2402eb08625a76f762fb73bb",
+			expectSpanID:  "5c301b3cb0f66539",
+			expectFlag:    1,
+		},
+	} {
+		t.Run(tc.header, func(t *testing.T) {
+			u := &UberTraceContext{}
+			h := http.Header{}
+			h.Add("uber-trace-id", tc.header)
+			ctx := u.Extract(context.Background(), propagation.HeaderCarrier(h))
+			sc := trace.SpanContextFromContext(ctx)
+			if !sc.IsValid() {
+				t.Fatalf("span context was not valid")
+			}
+			assertString(t, tc.expectTraceID, sc.TraceID().String())
+			assertString(t, tc.expectSpanID, sc.SpanID().String())
+			if expected := trace.TraceFlags(tc.expectFlag); expected != sc.TraceFlags() {
+				t.Fatalf("trace flags mismatch, expected: %v, actual: %v", expected, sc.TraceFlags())
+			}
+		})
+	}
+}


### PR DESCRIPTION
When we were extracing the span context from an uber-trace-id header, we didn't properly handle the case of flags=0. It was expecting, for the flags, a hex encoded string, but in fact, the flags is just a base 16 integer field.

The correct conversion is to just use ParseInt with base 16.

The test cases are taken from topic manager examples using the jaeger client with go-opentracing.