### PR TITLE
log: use slog for logging

### DIFF
--- a/example/basic/example_test.go
+++ b/example/basic/example_test.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	otelb "barney.ci/go-otel"
-	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -20,9 +20,10 @@ var tracer trace.Tracer
 
 func setup(ctx context.Context) {
 	tp, closer, err := otelb.OtelSetup(
+		ctx,
 		"barney.ci/go-otel/example/basic",
 		// logger first so that any errors can be reported.
-		otelb.WithLogger(logr.FromContextOrDiscard(ctx)),
+		otelb.WithLogger(slog.Default()),
 
 		otelb.WithEnvGate(),
 		otelb.WithShutdownTimeout(time.Minute),

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,6 @@ go 1.22
 toolchain go1.23.1
 
 require (
-	github.com/go-logr/logr v1.4.2
-	github.com/go-logr/stdr v1.2.2
 	github.com/segmentio/kafka-go v0.4.47
 	go.opentelemetry.io/contrib/samplers/jaegerremote v0.26.0
 	go.opentelemetry.io/otel v1.32.0
@@ -17,6 +15,8 @@ require (
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.23.0 // indirect


### PR DESCRIPTION
Use slog for logging from the stdlib to get rid of external logging dependencies.