### PR TITLE
readme: remove unnecessary envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ spec:
     spec:
       containers:
         env:
-        - name: OTEL_SDK_DISABLED
-          value: "false"
-        - name: OTEL_EXPORTER_OTLP_INSECURE
-          value: "true"
         - name: HOST_IP
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Remove unnecessary envs from the readme since the library already is able to determine whether to use insecure or not based on whether http or https is included.